### PR TITLE
Implement CRUD in CompaniesController

### DIFF
--- a/VSMS.Company.Application/Controllers/CompaniesController.cs
+++ b/VSMS.Company.Application/Controllers/CompaniesController.cs
@@ -6,7 +6,7 @@ using VSMS.Company.Domain.DTOs;
 using VSMS.Company.Domain.Exceptions;
 using VSMS.Company.Infrastructure.Interfaces;
 
-namespace VSMS.Application.Controllers;
+namespace VSMS.Company.Application.Controllers;
 
 [Authorize]
 [ApiController]

--- a/VSMS.Company.Application/Controllers/CompaniesController.cs
+++ b/VSMS.Company.Application/Controllers/CompaniesController.cs
@@ -1,14 +1,158 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using VSMS.Company.Domain.DTOs;
+using VSMS.Company.Domain.Exceptions;
 using VSMS.Company.Infrastructure.Interfaces;
 
-namespace VSMS.Company.Application.Controllers;
+namespace VSMS.Application.Controllers;
 
+[Authorize]
 [ApiController]
 [Route("[controller]")]
 public class CompaniesController(
     ILogger<CompaniesController> logger,
     ICompaniesService companiesService) : ControllerBase
 {
-    
+
+    /// <summary>
+    /// Method to get Company by id.
+    /// </summary>
+    /// <param name="companyId">Guid representation of Company ID.</param>
+    /// <returns>Model of Company.</returns>
+    [Authorize]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CompanyDto))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [HttpGet("{companyId:guid}")]
+    public async Task<IActionResult> GetCompanyById(Guid companyId)
+    {
+        try
+        {
+            var company = await companiesService.GetById(companyId);
+            return Ok(company);
+        }
+        catch (CompanyNotFoundException)
+        {
+            return NotFound();
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e.Message);
+            return StatusCode(500, e.Message);
+        }
+    }
+
+    /// <summary>
+    /// Method to create Company.
+    /// </summary>
+    /// <param name="model">Company model.</param>
+    /// <returns>Created Company model.</returns>
+    [Authorize]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CompanyDto))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [HttpPost]
+    public async Task<IActionResult> CreateCompany([FromBody] CompanyDto model)
+    {
+        try
+        {
+            var company = await companiesService.Create(model);
+            if (company is null)
+                return StatusCode(418, $"Created company with title: {model.Title} not found.");
+
+            return Ok(company);
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e.Message);
+            return StatusCode(500, e.Message);
+        }
+    }
+
+    /// <summary>
+    /// Method to update Company.
+    /// </summary>
+    /// <param name="companyId">Company ID.</param>
+    /// <param name="model">Updated Company model.</param>
+    /// <returns>Updated Company model.</returns>
+    [Authorize]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(CompanyDto))]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [HttpPut("{companyId:guid}")]
+    public async Task<IActionResult> UpdateCompany(Guid companyId, [FromBody] CompanyDto model)
+    {
+        try
+        {
+            if (companyId == Guid.Empty)
+                return BadRequest("Company Id is empty.");
+
+            var company = await companiesService.GetById(companyId);
+            if (company is null)
+                return NotFound($"Company with ID: {companyId} not found.");
+
+            var updatedCompany = await companiesService.Update(model);
+            return Ok(updatedCompany);
+        }
+        catch (CompanyNotFoundException)
+        {
+            return NotFound($"Company with ID: {companyId} not found.");
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e.Message);
+            return StatusCode(500, e.Message);
+        }
+    }
+
+    /// <summary>
+    /// Method to Delete Company by ID.
+    /// </summary>
+    /// <param name="companyId">Company ID.</param>
+    /// <returns>Indicates whether the deletion succeeded.</returns>
+    [Authorize]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status418ImATeapot)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    [HttpDelete("{companyId:guid}")]
+    public async Task<IActionResult> DeleteCompany(Guid companyId)
+    {
+        try
+        {
+            if (companyId == Guid.Empty)
+                return BadRequest("Company Id is empty.");
+
+            var company = await companiesService.GetById(companyId);
+            if (company is null)
+                return NotFound($"Company with ID: {companyId} not found.");
+
+            var result = await companiesService.DeleteById(companyId);
+
+            return result
+                ? NoContent()
+                : StatusCode(418);
+        }
+        catch (CompanyNotFoundException)
+        {
+            return NotFound($"Company with ID: {companyId} not found.");
+        }
+        catch (Exception e)
+        {
+            logger.LogError(e.Message);
+            return StatusCode(500, e.Message);
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary
- implement companies CRUD endpoints mirroring UsersController architecture
- add title existence check
- refine update/delete to check for null company and remove title check endpoint

## Testing
- `dotnet build VSMS.API.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685155dd0cb483229b562dd428a835d0