### PR TITLE
Add UserNotFoundException and controller handling

### DIFF
--- a/VSMS.Application/Controllers/UsersController.cs
+++ b/VSMS.Application/Controllers/UsersController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using VSMS.Domain.DTOs;
+using VSMS.Domain.Exceptions;
 using VSMS.Infrastructure.Interfaces;
 
 namespace VSMS.Application.Controllers;
@@ -57,10 +58,11 @@ public class UsersController(
         try
         {
             var user = await userService.GetUserProfileById(userId);
-            if (user is null)
-                return NotFound();
-            
             return Ok(user);
+        }
+        catch (UserNotFoundException)
+        {
+            return NotFound();
         }
         catch (Exception e)
         {
@@ -87,10 +89,11 @@ public class UsersController(
         try
         {
             var user = await userService.CreateUser(model);
-            if (user is null)
-                return StatusCode(418, $"Created user with email: {model.Email} not found.");
-            
             return Ok(user);
+        }
+        catch (UserNotFoundException)
+        {
+            return NotFound();
         }
         catch (Exception e)
         {
@@ -120,15 +123,12 @@ public class UsersController(
             if (userId == Guid.Empty)
                 return BadRequest("User Id is empty.");
 
-            var user = await userService.GetUserProfileById(userId);
-            if (user is null)
-                return NotFound($"User with ID: {userId} not found.");
-
             var updatedUser = await userService.UpdateUserProfile(model);
-            if (updatedUser is null)
-                return StatusCode(418, $"Updated user with ID: {userId} not found.");
-            
             return Ok(updatedUser);
+        }
+        catch (UserNotFoundException)
+        {
+            return NotFound($"User with ID: {userId} not found.");
         }
         catch (Exception e)
         {
@@ -158,15 +158,15 @@ public class UsersController(
             if (userId == Guid.Empty)
                 return BadRequest("User Id is empty.");
 
-            var user = await userService.GetUserProfileById(userId);
-            if (user is null)
-                return NotFound($"User with ID: {userId} not found.");
-
             var result = await userService.DeleteUserById(userId);
 
-            return result 
-                ? NoContent() 
+            return result
+                ? NoContent()
                 : StatusCode(418);
+        }
+        catch (UserNotFoundException)
+        {
+            return NotFound($"User with ID: {userId} not found.");
         }
         catch (Exception e)
         {

--- a/VSMS.Domain/Exceptions/UserNotFoundException.cs
+++ b/VSMS.Domain/Exceptions/UserNotFoundException.cs
@@ -1,0 +1,10 @@
+namespace VSMS.Domain.Exceptions;
+
+public class UserNotFoundException : Exception
+{
+    public UserNotFoundException(Guid id)
+        : base($"User with ID '{id}' was not found.") { }
+
+    public UserNotFoundException(string email)
+        : base($"User with email '{email}' was not found.") { }
+}

--- a/VSMS.Infrastructure/Services/UserService.cs
+++ b/VSMS.Infrastructure/Services/UserService.cs
@@ -4,6 +4,7 @@ using VSMS.Domain;
 using VSMS.Domain.DTOs;
 using VSMS.Domain.Entities;
 using VSMS.Domain.Models;
+using VSMS.Domain.Exceptions;
 using VSMS.Infrastructure.Interfaces;
 using VSMS.Repository;
 
@@ -138,6 +139,9 @@ public class UserService(
         try
         {
             var user = await userManager.FindByIdAsync(id.ToString());
+            if (user is null)
+                throw new UserNotFoundException(id);
+
             return user;
         }
         catch (Exception e)
@@ -156,7 +160,7 @@ public class UserService(
         {
             var user = await userManager.FindByIdAsync(userId.ToString());
             if (user is null)
-                return null;
+                throw new UserNotFoundException(userId);
 
             var roles = await userManager.GetRolesAsync(user);
 
@@ -191,7 +195,7 @@ public class UserService(
             
             var createdUser = await userManager.FindByEmailAsync(model.Email);
             if (createdUser is null)
-                return null;
+                throw new UserNotFoundException(model.Email);
             
             var roleAssignResult = await userManager.AddToRoleAsync(createdUser, model.RoleName);
             if (!roleAssignResult.Succeeded)
@@ -222,7 +226,7 @@ public class UserService(
         {
             var user = await userManager.FindByIdAsync(updatingUser.Id.ToString());
             if (user is null)
-                throw new Exception($"User to update with ID: {updatingUser.Id} not found.");
+                throw new UserNotFoundException(updatingUser.Id);
 
             user.FirstName = updatingUser.FirstName ?? user.FirstName;
             user.LastName = updatingUser.LastName ?? user.LastName;
@@ -274,7 +278,7 @@ public class UserService(
         {
             var user = await userManager.FindByIdAsync(userId.ToString());
             if (user is null)
-                throw new Exception($"User to delete with ID: {userId} not found.");
+                throw new UserNotFoundException(userId);
 
             var deleteResult = await userManager.DeleteAsync(user);
             if (!deleteResult.Succeeded)


### PR DESCRIPTION
## Summary
- implement `UserNotFoundException` similar to `CompanyNotFoundException`
- update `UserService` to throw `UserNotFoundException` when users are missing
- handle `UserNotFoundException` in `UsersController`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851afceedf0832294d15ce7b23123fd