### PR TITLE
Fix migrations by ignoring unrelated entities

### DIFF
--- a/VSMS.Repository/CompaniesRepository.cs
+++ b/VSMS.Repository/CompaniesRepository.cs
@@ -10,6 +10,9 @@ public class CompaniesRepository(
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        modelBuilder.Ignore<Stock>();
+        modelBuilder.Ignore<ApplicationUser>();
+
         modelBuilder.Entity<Company>()
             .HasMany(c => c.Users)
             .WithOne()

--- a/VSMS.Repository/StocksRepository.cs
+++ b/VSMS.Repository/StocksRepository.cs
@@ -10,6 +10,9 @@ public class StocksRepository(
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        modelBuilder.Ignore<Company>();
+        modelBuilder.Ignore<ApplicationUser>();
+
         modelBuilder.Entity<Stock>()
             .ToTable("Stocks",
                 s => s.IsTemporal(t =>


### PR DESCRIPTION
## Summary
- update `CompaniesRepository` and `StocksRepository` to ignore unrelated entity types in `OnModelCreating`

These changes prevent EF Core from trying to create `AspNetUsers`, `Stocks`, or other cross tables when running migrations for different contexts.

## Testing
- `dotnet build VSMS.API.sln -v minimal` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d0f178dc4832282c6fe0481083f49