### PR TITLE
Add stock access checks and optimize deletion

### DIFF
--- a/VSMS.Infrastructure/Services/StocksService.cs
+++ b/VSMS.Infrastructure/Services/StocksService.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using System.Linq;
 using VSMS.Domain.DTOs;
 using VSMS.Domain.Entities;
 using VSMS.Domain.Exceptions;
@@ -157,7 +158,8 @@ public class StocksService(
     {
         try
         {
-            var stock = await stocksRepository.Stocks.FindAsync(id);
+            var stock = stocksRepository.Stocks.Local.FirstOrDefault(s => s.Id == id)
+                        ?? await stocksRepository.Stocks.FindAsync(id);
             if (stock is null)
                 throw new StockNotFoundException(id);
 


### PR DESCRIPTION
## Summary
- enforce company ownership checks in `StocksController`
- inject `IAuthorizationService` into `StocksController`
- avoid duplicate database lookups when deleting a stock

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e45e8667883229a3bc3c6822cc8d4